### PR TITLE
사용자 쿠폰 발급 @Transactoinal 적용 범위 변경

### DIFF
--- a/src/main/java/com/ayuconpon/coupon/domain/CouponRepository.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/CouponRepository.java
@@ -5,6 +5,7 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
@@ -19,5 +20,13 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     @Query("select c from Coupon c " +
             "where c.issuePeriod.startedAt <= :currentTime and :currentTime <= c.issuePeriod.finishedAt")
     List<Coupon> findCouponsInProgress(LocalDateTime currentTime, Pageable pageable);
+
+    @Modifying(clearAutomatically = true)
+    @Query(value =  "update coupon " +
+                    "set left_quantity = left_quantity - 1 " +
+                    "where coupon_id = :couponId and left_quantity > 0 " +
+                    "and :currentTime BETWEEN started_at and finished_at"
+                    , nativeQuery = true)
+    int decrease(Long couponId, LocalDateTime currentTime);
 
 }

--- a/src/main/java/com/ayuconpon/usercoupon/controller/UserCouponController.java
+++ b/src/main/java/com/ayuconpon/usercoupon/controller/UserCouponController.java
@@ -8,6 +8,8 @@ import com.ayuconpon.usercoupon.controller.response.ShowUserCouponsResponse;
 import com.ayuconpon.usercoupon.controller.response.UseUserCouponResponse;
 import com.ayuconpon.usercoupon.service.*;
 import com.ayuconpon.common.resolver.UserId;
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponCommand;
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -22,7 +24,7 @@ import java.util.List;
 @RestController
 public class UserCouponController {
 
-    private final IssueUserCouponService issueUserCouponService;
+    private final IssueUserCouponFacade issueUserCouponfacade;
     private final UseUserCouponService useUserCouponService;
     private final ShowUserCouponService showUserCouponService;
 
@@ -41,7 +43,7 @@ public class UserCouponController {
             @Valid @RequestBody IssueUserCouponRequest issueUserCouponRequest) {
 
         IssueUserCouponCommand command = new IssueUserCouponCommand(userId, issueUserCouponRequest.getCouponId());
-        Long issuedUserCouponId = issueUserCouponService.issue(command);
+        Long issuedUserCouponId = issueUserCouponfacade.issue(command);
 
         return ResponseEntity.ok(new IssueUserCouponResponse(issuedUserCouponId));
     }

--- a/src/main/java/com/ayuconpon/usercoupon/service/issue/CouponQuantityService.java
+++ b/src/main/java/com/ayuconpon/usercoupon/service/issue/CouponQuantityService.java
@@ -1,0 +1,22 @@
+package com.ayuconpon.usercoupon.service.issue;
+
+import com.ayuconpon.coupon.domain.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class CouponQuantityService {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public void decrease(IssueUserCouponCommand command, LocalDateTime currentTime) {
+        int result = couponRepository.decrease(command.couponId(), currentTime);
+        if (result != 1) throw new IllegalStateException("쿠폰의 재고가 없습니다.");
+    }
+
+}

--- a/src/main/java/com/ayuconpon/usercoupon/service/issue/IssueUserCouponCommand.java
+++ b/src/main/java/com/ayuconpon/usercoupon/service/issue/IssueUserCouponCommand.java
@@ -1,4 +1,4 @@
-package com.ayuconpon.usercoupon.service;
+package com.ayuconpon.usercoupon.service.issue;
 
 import org.springframework.util.Assert;
 

--- a/src/main/java/com/ayuconpon/usercoupon/service/issue/IssueUserCouponFacade.java
+++ b/src/main/java/com/ayuconpon/usercoupon/service/issue/IssueUserCouponFacade.java
@@ -1,0 +1,24 @@
+package com.ayuconpon.usercoupon.service.issue;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class IssueUserCouponFacade {
+
+    private final IssueUserCouponValidator validator;
+    private final CouponQuantityService couponQuantityService;
+    private final IssueUserCouponService issueUserCouponService;
+
+    public Long issue(IssueUserCouponCommand command) {
+        validator.validate(command);
+
+        LocalDateTime currentTime = LocalDateTime.now();
+        couponQuantityService.decrease(command, currentTime);
+        return issueUserCouponService.issue(command, currentTime);
+    }
+
+}

--- a/src/main/java/com/ayuconpon/usercoupon/service/issue/IssueUserCouponService.java
+++ b/src/main/java/com/ayuconpon/usercoupon/service/issue/IssueUserCouponService.java
@@ -1,0 +1,32 @@
+package com.ayuconpon.usercoupon.service.issue;
+
+import com.ayuconpon.common.exception.NotFoundCouponException;
+import com.ayuconpon.coupon.domain.CouponRepository;
+import com.ayuconpon.coupon.domain.entity.Coupon;
+import com.ayuconpon.usercoupon.domain.UserCouponRepository;
+import com.ayuconpon.usercoupon.domain.entity.UserCoupon;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class IssueUserCouponService {
+
+    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+
+    @Transactional
+    public Long issue(IssueUserCouponCommand command, LocalDateTime currentTime) {
+        Coupon coupon = couponRepository.findById(command.couponId())
+                .orElseThrow(NotFoundCouponException::new);
+        return saveCoupon(new UserCoupon(command.userId(), coupon, currentTime));
+    }
+
+    private Long saveCoupon(UserCoupon issuedCoupon) {
+        return userCouponRepository.save(issuedCoupon).getUserCouponId();
+    }
+
+}

--- a/src/main/java/com/ayuconpon/usercoupon/service/issue/IssueUserCouponValidator.java
+++ b/src/main/java/com/ayuconpon/usercoupon/service/issue/IssueUserCouponValidator.java
@@ -1,52 +1,31 @@
-package com.ayuconpon.usercoupon.service;
+package com.ayuconpon.usercoupon.service.issue;
 
-import com.ayuconpon.coupon.domain.entity.Coupon;
-import com.ayuconpon.usercoupon.domain.entity.UserCoupon;
-import com.ayuconpon.coupon.domain.CouponRepository;
-import com.ayuconpon.usercoupon.domain.UserCouponRepository;
 import com.ayuconpon.common.exception.DuplicatedCouponException;
 import com.ayuconpon.common.exception.NotFoundCouponException;
 import com.ayuconpon.common.exception.RequireRegistrationException;
+import com.ayuconpon.coupon.domain.CouponRepository;
 import com.ayuconpon.user.domain.UserRepository;
+import com.ayuconpon.usercoupon.domain.UserCouponRepository;
+import com.ayuconpon.usercoupon.domain.entity.UserCoupon;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
-@RequiredArgsConstructor
-@Transactional
 @Service
-public class IssueUserCouponService {
+@RequiredArgsConstructor
+public class IssueUserCouponValidator {
 
     private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
     private final UserRepository userRepository;
 
-    public Long issue(IssueUserCouponCommand command) {
-        validate(command);
-        UserCoupon issuedUserCoupon = issueUserCoupon(command);
-        return saveCoupon(issuedUserCoupon);
-    }
-
-    private void validate(IssueUserCouponCommand command) {
+    @Transactional(readOnly = true)
+    public void validate(IssueUserCouponCommand command) {
         validateRegisteredCoupon(command);
         validateRegisteredUser(command);
         validateDuplicatedCoupon(command);
-    }
-
-    private UserCoupon issueUserCoupon(IssueUserCouponCommand command) {
-        Coupon coupon = couponRepository.findByIdWithPessimisticLock(command.couponId());
-
-        LocalDateTime currentTime = LocalDateTime.now();
-
-        coupon.decrease(currentTime);
-        return new UserCoupon(command.userId(), coupon, currentTime);
-    }
-
-    private Long saveCoupon(UserCoupon issuedCoupon) {
-        return userCouponRepository.save(issuedCoupon).getUserCouponId();
     }
 
     private void validateRegisteredCoupon(IssueUserCouponCommand command) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,7 +2,8 @@ insert into coupon(coupon_id, name, discount_type, discount_rate, discount_price
 values (1, 'event fix coupon A','FIX_DISCOUNT', null, 1000, 1000, 1000,'2023-09-14', '2024-10-14', 24, 10000),
        (2, 'event fix coupon B','FIX_DISCOUNT', null, 1000, 1000, 1000,'2023-09-14', '2024-10-14', 24, 10000),
        (3, 'event rate coupon C','RATE_DISCOUNT', 0.1, null, 1000, 1000,'2023-09-14', '2024-10-14', 24, 10000),
-       (4, 'event rate coupon D','RATE_DISCOUNT', 0.1, null, 1000, 1000,'2023-09-14', '2024-10-14', 24, 10000);
+       (4, 'event rate coupon D','RATE_DISCOUNT', 0.1, null, 1000, 1000,'2023-09-14', '2024-10-14', 24, 10000),
+       (5, 'zero quantity coupon','RATE_DISCOUNT', 0.1, null, 1000, 0,'2023-09-14', '2024-10-14', 24, 10000);
 
 
 insert into user(user_id, name, status)

--- a/src/test/java/com/ayuconpon/UserCoupon/controller/CouponControllerTest.java
+++ b/src/test/java/com/ayuconpon/UserCoupon/controller/CouponControllerTest.java
@@ -7,6 +7,8 @@ import com.ayuconpon.usercoupon.controller.request.UseUserCouponRequest;
 import com.ayuconpon.usercoupon.controller.request.IssueUserCouponRequest;
 import com.ayuconpon.usercoupon.domain.entity.UserCoupon;
 import com.ayuconpon.usercoupon.service.*;
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponCommand;
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponFacade;
 import com.ayuconpon.util.Coupons;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -39,7 +41,7 @@ class CouponControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private IssueUserCouponService issueUserCouponService;
+    private IssueUserCouponFacade issueUserCouponService;
     @MockBean
     private UseUserCouponService useUserCouponService;
     @MockBean

--- a/src/test/java/com/ayuconpon/UserCoupon/service/IssueCouponCommandTest.java
+++ b/src/test/java/com/ayuconpon/UserCoupon/service/IssueCouponCommandTest.java
@@ -1,5 +1,6 @@
 package com.ayuconpon.usercoupon.service;
 
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponCommand;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/ayuconpon/UserCoupon/service/IssueCouponServiceTest.java
+++ b/src/test/java/com/ayuconpon/UserCoupon/service/IssueCouponServiceTest.java
@@ -6,12 +6,13 @@ import com.ayuconpon.coupon.domain.entity.Coupon;
 import com.ayuconpon.common.exception.DuplicatedCouponException;
 import com.ayuconpon.common.exception.NotFoundCouponException;
 import com.ayuconpon.common.exception.RequireRegistrationException;
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponCommand;
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponFacade;
 import org.junit.jupiter.api.AfterEach;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.CountDownLatch;
@@ -24,7 +25,7 @@ import static org.assertj.core.api.Assertions.*;
 class IssueCouponServiceTest extends IssueCouponRepositorySupport {
 
     @Autowired
-    private IssueUserCouponService issueCouponService;
+    private IssueUserCouponFacade issueCouponService;
     @Autowired
     private CouponRepository couponRepository;
     @Autowired
@@ -83,6 +84,18 @@ class IssueCouponServiceTest extends IssueCouponRepositorySupport {
         assertThatThrownBy(() -> issueCouponService.issue(command))
                 .isInstanceOf(NotFoundCouponException.class)
                 .hasMessage("발급 요청된 쿠폰이 존재하지 않습니다.");
+    }
+
+    @DisplayName("재고가 없는 쿠폰은 발급할 수 없다.")
+    @Test
+    public void issueCouponForZeroLeftQuantityCoupon () {
+        //given
+        IssueUserCouponCommand command = new IssueUserCouponCommand(1L, 5L);
+
+        //when then
+        assertThatThrownBy(() -> issueCouponService.issue(command))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("쿠폰의 재고가 없습니다.");
     }
 
     @DisplayName("쿠폰을 발급하면, 쿠폰 재고가 감소한다.")

--- a/src/test/java/com/ayuconpon/UserCoupon/service/ShowUserCouponServiceTest.java
+++ b/src/test/java/com/ayuconpon/UserCoupon/service/ShowUserCouponServiceTest.java
@@ -1,6 +1,8 @@
 package com.ayuconpon.usercoupon.service;
 
 
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponCommand;
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponFacade;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +22,7 @@ class ShowUserCouponServiceTest {
     @Autowired
     private ShowUserCouponService showUserCouponService;
     @Autowired
-    private IssueUserCouponService issueUserCouponService;
+    private IssueUserCouponFacade issueUserCouponService;
 
     @DisplayName("사용자의 쿠폰 목록을 조회할 수 있다.")
     @Test

--- a/src/test/java/com/ayuconpon/UserCoupon/service/UseUserCouponServiceTest.java
+++ b/src/test/java/com/ayuconpon/UserCoupon/service/UseUserCouponServiceTest.java
@@ -4,6 +4,8 @@ import com.ayuconpon.common.Money;
 import com.ayuconpon.common.exception.AlreadyUsedUserCouponException;
 import com.ayuconpon.common.exception.NotFoundUserCouponException;
 import com.ayuconpon.common.exception.RequireRegistrationException;
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponCommand;
+import com.ayuconpon.usercoupon.service.issue.IssueUserCouponFacade;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +22,7 @@ class UseUserCouponServiceTest extends IssueCouponRepositorySupport {
     @Autowired
     private UseUserCouponService useUserCouponService;
     @Autowired
-    private IssueUserCouponService issueUserCouponService;
+    private IssueUserCouponFacade issueUserCouponService;
 
     @DisplayName("쿠폰 적용 요청을 보낼 수 있다.")
     @Test


### PR DESCRIPTION
# 완료 작업

- 사용자 쿠폰 발급 서비스의 `Lock`을 소유한 트랜잭션 범위 변경

# 작업 이유

현재 코드는 사용자 쿠폰 발급 기능을 구현하기 위해, `Lock` 을 소유한 트랜잭션의 범위가 너무 넓습니다.
위의 이유로, `Lock` 획득을 위해 대기중인 트랜잭션이 많아 코드 수정이 필요했습니다.

# 결과 

TPS : 190.2 -> 259.5 (약 36%) 성능 향상

## 변경 전

- Lock 소유 트랜잭션  : 쿠폰 재고 감소 로직 + 사용자 쿠폰 저장 로직

![image](https://github.com/f-lab-edu/AYU-Coupon-Service/assets/80495427/9d72b2a0-1b40-4fd0-9560-8438da75210d)


## 변경 후

- Lock 소유 트랜잭션 1 : 쿠폰 재고 감소 로직
- Lock 소유 트랜잭션 2 : 사용자 쿠폰 저장 로직

![image](https://github.com/f-lab-edu/AYU-Coupon-Service/assets/80495427/da8dee9d-ee93-4e50-9501-e452408740a7)



# 추가 이슈

쿠폰 재고 감소 트랜잭션과 사용자 쿠폰 트랜잭션을 별도의 트랜잭션에서 실행하도록 하여 성능을 높였습니다.

하지만, 아래의 이슈가 존재합니다.
- 쿠폰 재고 감소 트랜잭션은 성공
- 하지만 사용자 쿠폰 트랜잭션이 실패할 경우 어떻게 복구할 것인지?

위의 이슈를 해결하기 위해, 좀 더 고민후 PR 하도록 하겠습니다.

