### PR TITLE
Lock으로 사용자 기준 특정 기능 동시 실행 막기

### DIFF
--- a/src/main/java/com/ayucoupon/common/handler/CouponExceptionHandler.java
+++ b/src/main/java/com/ayucoupon/common/handler/CouponExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.ConcurrentModificationException;
+
 @RestControllerAdvice(basePackages = "com.ayucoupon")
 public class CouponExceptionHandler {
 
@@ -27,7 +29,13 @@ public class CouponExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(e.getMessage());
     }
-    
+
+    @ExceptionHandler(ConcurrentModificationException.class)
+    public ResponseEntity<String> handle(ConcurrentModificationException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(e.getMessage());
+    }
+
     @ExceptionHandler(BaseCustomException.class)
     public ResponseEntity<String> handle(BaseCustomException e) {
         return ResponseEntity.status(e.getStatus())

--- a/src/main/java/com/ayucoupon/common/lock/RunnerLock.java
+++ b/src/main/java/com/ayucoupon/common/lock/RunnerLock.java
@@ -1,0 +1,37 @@
+package com.ayucoupon.common.lock;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class RunnerLock {
+
+    private final Lock lock;
+    private int count;
+
+    public RunnerLock() {
+        this.lock = new ReentrantLock(true);
+        this.count = 0;
+    }
+
+    public boolean tryLock() {
+        return lock.tryLock();
+    }
+
+    public boolean tryLock(Long time, TimeUnit unit) throws InterruptedException {
+        return lock.tryLock(time, unit);
+    }
+
+    public void unLock() {
+        lock.unlock();
+    }
+
+    public int increase() {
+        return ++count;
+    }
+
+    public int decrease() {
+        return --count;
+    }
+
+}

--- a/src/main/java/com/ayucoupon/common/lock/UserExclusiveRunner.java
+++ b/src/main/java/com/ayucoupon/common/lock/UserExclusiveRunner.java
@@ -1,0 +1,47 @@
+package com.ayucoupon.common.lock;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import java.time.Duration;
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@Component
+@Slf4j
+public class UserExclusiveRunner {
+
+    private final ConcurrentMap<Long, RunnerLock> map = new ConcurrentHashMap<>();
+
+    public <T> T call(Long userId, Duration tryLockTimeout, Supplier<T> f) {
+        Assert.notNull(tryLockTimeout, "tryLockTimeout must not be null");
+
+        RunnerLock lock = map.computeIfAbsent(userId, k -> new RunnerLock());
+        lock.increase();
+        try {
+            log.debug("Method \"{}\" tried to get lock of \"{}\"", f.getClass().getSimpleName(), this.getClass().getSimpleName());
+            if (lock.tryLock(tryLockTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                log.debug("User {} get lock of \"{}\"", userId, this.getClass().getSimpleName());
+                try {
+                    return f.get();
+                } finally {
+                    int count = lock.decrease();
+                    if (count <= 0) {
+                        map.remove(userId, lock);
+                    }
+                    log.debug("User {} release lock of \"{}\"", userId, this.getClass().getSimpleName());
+                    lock.unLock();
+                }
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        log.debug("User {} fail to get Lock of \"{}\"", userId, this.getClass().getSimpleName());
+        throw new ConcurrentModificationException("동시에 같은 요청을 보낼 수 없습니다.");
+    }
+
+}


### PR DESCRIPTION
# 완료작업

사용자 기준, 특정 기능 동시 실행을 막을 수 있는, Lock 개발

# 배경

동일한 사용자가 사용자 쿠폰 발급을 동시에 요청했을 경우, DB의 유니크 키 제약조건에 의해 예외가 발생하였습니다.  
위의 이유로, 같은 사용자가 같은 기능을 동시에 실행하지 못하도록 코드를 개발하였습니다.
