### PR TITLE
서비스 계층에 데이터소스 라우팅 어노테이션 추가

### DIFF
--- a/src/main/java/com/ayucoupon/coupon/service/ShowCouponsService.java
+++ b/src/main/java/com/ayucoupon/coupon/service/ShowCouponsService.java
@@ -1,5 +1,6 @@
 package com.ayucoupon.coupon.service;
 
+import com.ayucoupon.common.aop.multidatasource.DataSource;
 import com.ayucoupon.coupon.domain.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -19,6 +20,7 @@ public class ShowCouponsService {
 
     private static final String COUPON_ID = "couponId";
 
+    @DataSource("secondary")
     public List<CouponDto> getCouponsInProgress(LocalDateTime currentTime, Pageable pageable) {
         Pageable pageRequest = PageRequest.of(
                 pageable.getPageNumber(),

--- a/src/main/java/com/ayucoupon/usercoupon/service/ShowUserCouponService.java
+++ b/src/main/java/com/ayucoupon/usercoupon/service/ShowUserCouponService.java
@@ -1,5 +1,6 @@
 package com.ayucoupon.usercoupon.service;
 
+import com.ayucoupon.common.aop.multidatasource.DataSource;
 import com.ayucoupon.coupon.domain.CouponRepository;
 import com.ayucoupon.coupon.domain.entity.Coupon;
 import com.ayucoupon.usercoupon.domain.UserCouponRepository;
@@ -26,6 +27,7 @@ public class ShowUserCouponService {
 
     private static final String USER_COUPON_ID = "userCouponId";
 
+    @DataSource("primary")
     public List<UserCouponDto> getUnexpiredUserCoupons(Long userId, LocalDateTime currentTime, Pageable pageable) {
         Pageable pageRequest = PageRequest.of(
                 pageable.getPageNumber(),

--- a/src/main/java/com/ayucoupon/usercoupon/service/UseUserCouponService.java
+++ b/src/main/java/com/ayucoupon/usercoupon/service/UseUserCouponService.java
@@ -1,6 +1,7 @@
 package com.ayucoupon.usercoupon.service;
 
 import com.ayucoupon.common.Money;
+import com.ayucoupon.common.aop.multidatasource.DataSource;
 import com.ayucoupon.common.exception.NotFoundUserCouponException;
 import com.ayucoupon.coupon.domain.CouponRepository;
 import com.ayucoupon.coupon.domain.entity.Coupon;
@@ -21,6 +22,7 @@ public class UseUserCouponService {
     private final CouponRepository couponRepository;
 
     @Transactional
+    @DataSource("primary")
     public Money use(UseUserCouponCommand command) {
         return applyUserCoupon(command);
     }

--- a/src/main/java/com/ayucoupon/usercoupon/service/issue/IssueUserCouponService.java
+++ b/src/main/java/com/ayucoupon/usercoupon/service/issue/IssueUserCouponService.java
@@ -1,6 +1,7 @@
 package com.ayucoupon.usercoupon.service.issue;
 
 import com.ayucoupon.common.lock.UserExclusiveRunner;
+import com.ayucoupon.common.aop.multidatasource.DataSource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +15,7 @@ public class IssueUserCouponService {
     private final IssueValidator issueValidator;
     private final UserExclusiveRunner userExclusiveRunner;
 
+    @DataSource("primary")
     public Long issue(IssueUserCouponCommand command) {
         return userExclusiveRunner.call(command.userId(),
                 Duration.ofSeconds(30),


### PR DESCRIPTION
# 완료 작업

서비스 계층에 데이터 소스 라우팅 어노테이션 추가

# PR 요약

1. 사용자 쿠폰 조회, 발급, 사용 요청은 모두 Primary DB를 보도록 설정하였습니다.
2. 쿠폰 조회 요청은 Secondary DB를 보도록 설정하였습니다.

# 사용자 쿠폰 조회 요청을 Primary DB를 보도록 한 이유

사용자 쿠폰 조회 요청에서 사용자 쿠폰의 정보는 Primary DB에서 조회하도록 설정하였습니다.
그 이유는 Replication 복제 지연 이슈로, 사용자가 쿠폰을 발급하였지만, 조회되지 않는 이슈가 발생할 수 있다고 판단하여, 클라이언트의 응답 만족도를 높이기 위함입니다.